### PR TITLE
Bump spring web to 5.1.13.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <slf4jVersion>1.6.1</slf4jVersion>
         <org.fasterxml.jackson>2.10.0</org.fasterxml.jackson>
         <org.springframework.boot.version>2.1.7.RELEASE</org.springframework.boot.version>
-        <org.springframework.web.version>5.1.9.RELEASE</org.springframework.web.version>
+        <org.springframework.web.version>5.1.13.RELEASE</org.springframework.web.version>
         <hotels.oss.plugin.config.version>1.2.2</hotels.oss.plugin.config.version>
         <license.maven.plugin.version>3.0</license.maven.plugin.version>
         <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>


### PR DESCRIPTION
# dr-shadow PR

spring-webmvc had a security vulnerability (https://github.com/advisories/GHSA-8wx2-9q48-vm9r) and a recommended fix is to patch it up to v5.1.13

## Changed
* Upgrade spring-core to v5.1.13
* Upgrade spring-web to v5.1.13
* Upgrade spring-webmvc to v5.1.13
* Upgrade spring-tx to v5.1.13

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] This template filled (above this section)
- [ ] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
- [ ] Milestone selected
- [x] All files reviewed before sending to reviewers
- [ ] Any annotations for reviewers have been added
      (with preference of annotating directly in code comments)
- [ ] PR builds successfully
- [ ] Tested with the provided sample test app